### PR TITLE
Generate binaries in C:/robotology/vcpkg for compatibility with the installer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,6 @@ jobs:
         rm -Force -Recurse -Path 'C:\Program Files\dotnet'
         rm -Force -Recurse -Path 'C:\Program Files (x86)\Google'
         rm -Force -Recurse -Path 'C:\tools\php'
-        rm -Force -Recurse -Path 'C:\go'
         rm -Force -Recurse -Path 'C:\Rust'
 
     - name: Check free space 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,12 @@ jobs:
       run: |
         rm -Force -Recurse -Path 'C:\Program Files (x86)\Android'
         rm -Force -Recurse -Path 'C:\Program Files\Java'
-    
+        rm -Force -Recurse -Path 'C:\Program Files\dotnet'
+        rm -Force -Recurse -Path 'C:\Program Files (x86)\Google'
+        rm -Force -Recurse -Path 'C:\tools\php'
+        rm -Force -Recurse -Path 'C:\go'
+        rm -Force -Recurse -Path 'C:\Rust'
+
     - name: Check free space 
       shell: bash 
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     # Workaround for https://github.community/t5/GitHub-Actions/Windows-tests-worked-yesterday-broken-today/td-p/43574
     - name: Override bash shell PATH (windows-latest)
       run: echo "::add-path::C:\Program Files\Git\bin"
-      if: matrix.os == 'windows-latest'
+      if: matrix.os == 'windows-2019'
     
     - name: Download custom vcpkg and additional ports 
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,24 +14,25 @@ jobs:
     - name: Download custom vcpkg and additional ports 
       shell: bash
       run: |
-        git clone -b 2019.10 https://github.com/microsoft/vcpkg  C:/vcpkg-robotology
-        C:/vcpkg-robotology/bootstrap-vcpkg.sh
+        mkdir C:/robotology
+        git clone -b 2019.10 https://github.com/microsoft/vcpkg  C:/robotology/vcpkg
+        C:/robotology/vcpkg/bootstrap-vcpkg.sh
         git clone https://github.com/robotology-dependencies/robotology-vcpkg-binary-ports C:/robotology-vcpkg-binary-ports
 
     - name: Install vcpkg ports
       shell: bash
       run: |
         # TinyXML is not installed as a workaround for https://github.com/robotology/ycm/pull/296
-        C:/vcpkg-robotology/vcpkg.exe --overlay-ports=C:/robotology-vcpkg-binary-ports install --triplet x64-windows ace freeglut gsl eigen3 ode libxml2 eigen3 opencv3 matio sdl1 sdl2 qt5-base  ipopt-binary 
+        C:/robotology/vcpkg/vcpkg.exe --overlay-ports=C:/robotology-vcpkg-binary-ports install --triplet x64-windows ace freeglut gsl eigen3 ode libxml2 eigen3 opencv3 matio sdl1 sdl2 qt5-base  ipopt-binary 
         # Remove temporary files https://github.com/Microsoft/vcpkg/blob/master/docs/about/faq.md#how-can-i-remove-temporary-files
-        rm -rf C:/vcpkg-robotology/buildtrees 
-        C:/vcpkg-robotology/vcpkg.exe --overlay-ports=C:/robotology-vcpkg-binary-ports install --triplet x64-windows qt5-declarative qt5-multimedia qt5-quickcontrols2
+        rm -rf C:/robotology/vcpkg/buildtrees 
+        C:/robotology/vcpkg/vcpkg.exe --overlay-ports=C:/robotology-vcpkg-binary-ports install --triplet x64-windows qt5-declarative qt5-multimedia qt5-quickcontrols2
         # Remove temporary files https://github.com/Microsoft/vcpkg/blob/master/docs/about/faq.md#how-can-i-remove-temporary-files
-        rm -rf C:/vcpkg-robotology/buildtrees 
-        rm -rf C:/vcpkg-robotology/packages 
-        rm -rf C:/vcpkg-robotology/downloads 
+        rm -rf C:/robotology/vcpkg/buildtrees 
+        rm -rf C:/robotology/vcpkg/packages 
+        rm -rf C:/robotology/vcpkg/downloads 
         
     - uses: actions/upload-artifact@master
       with:
         name: vcpkg-robotology
-        path: C:/vcpkg-robotology
+        path: C:/robotology/vcpkg

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,6 @@ jobs:
     # Workaround for https://github.community/t5/GitHub-Actions/Windows-tests-worked-yesterday-broken-today/td-p/43574
     - name: Override bash shell PATH (windows-latest)
       run: echo "::add-path::C:\Program Files\Git\bin"
-      if: matrix.os == 'windows-2019'
     
     - name: Download custom vcpkg and additional ports 
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       shell: bash
       run: |
         mkdir C:/robotology
-        git clone -b 2019.10 https://github.com/microsoft/vcpkg  C:/robotology/vcpkg
+        git clone -b 2019.12 https://github.com/microsoft/vcpkg  C:/robotology/vcpkg
         C:/robotology/vcpkg/bootstrap-vcpkg.sh
         git clone https://github.com/robotology-dependencies/robotology-vcpkg-binary-ports C:/robotology-vcpkg-binary-ports
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
+  
+    # Workaround for https://github.community/t5/GitHub-Actions/Windows-tests-worked-yesterday-broken-today/td-p/43574
+    - name: Override bash shell PATH (windows-latest)
+      run: echo "::add-path::C:\Program Files\Git\bin"
+      if: matrix.os == 'windows-latest'
     
     - name: Download custom vcpkg and additional ports 
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,15 +12,16 @@ jobs:
     - uses: actions/checkout@v1
   
     # Workaround for https://github.community/t5/GitHub-Actions/Windows-tests-worked-yesterday-broken-today/td-p/43574
-    - name: Override bash shell PATH (windows-latest)
-      run: echo "::add-path::C:\Program Files\Git\bin"
+    #- name: Override bash shell PATH (windows-latest)
+    #  run: echo "::add-path::C:\Program Files\Git\bin"
     
     - name: Download custom vcpkg and additional ports 
       shell: bash
       run: |
         mkdir C:/robotology
-        git clone https://github.com/microsoft/vcpkg  C:/robotology/vcpkg
+        git clone -b 2019.10 https://github.com/microsoft/vcpkg  C:/robotology/vcpkg
         C:/robotology/vcpkg/bootstrap-vcpkg.sh
+        sleep 1
         git clone https://github.com/robotology-dependencies/robotology-vcpkg-binary-ports C:/robotology-vcpkg-binary-ports
 
     - name: Install vcpkg ports

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,19 @@ jobs:
       shell: bash 
       run: |
         df -h
+    
+    # Workaround for https://github.com/actions/virtual-environments/issues/326 until the fix is deployed
+    - name: Remove
+      shell: bash 
+      run: |
+        rm -rf C:\Program Files (x86)\Android
+        rm -rf ${BOOST_ROOT_1_69_0}
+        rm -rf C:\Program Files\Java
+    
+    - name: Check free space 
+      shell: bash 
+      run: |
+        df -h
   
     # Workaround for https://github.community/t5/GitHub-Actions/Windows-tests-worked-yesterday-broken-today/td-p/43574
     - name: Override bash shell PATH (windows-latest)
@@ -32,10 +45,7 @@ jobs:
       shell: bash
       run: |
         # TinyXML is not installed as a workaround for https://github.com/robotology/ycm/pull/296
-        C:/robotology/vcpkg/vcpkg.exe --overlay-ports=C:/robotology-vcpkg-binary-ports install --triplet x64-windows openssl
-        # Remove temporary files https://github.com/Microsoft/vcpkg/blob/master/docs/about/faq.md#how-can-i-remove-temporary-files
-        rm -rf C:/robotology/vcpkg/buildtrees 
-        C:/robotology/vcpkg/vcpkg.exe --overlay-ports=C:/robotology-vcpkg-binary-ports install --triplet x64-windows ace freeglut gsl eigen3 ode libxml2 eigen3 opencv3 matio sdl1 sdl2 qt5-base  ipopt-binary 
+        C:/robotology/vcpkg/vcpkg.exe --overlay-ports=C:/robotology-vcpkg-binary-ports install --triplet x64-windows ace freeglut gsl eigen3 ode openssl libxml2 eigen3 opencv3 matio sdl1 sdl2 qt5-base  ipopt-binary 
         # Remove temporary files https://github.com/Microsoft/vcpkg/blob/master/docs/about/faq.md#how-can-i-remove-temporary-files
         rm -rf C:/robotology/vcpkg/buildtrees 
         C:/robotology/vcpkg/vcpkg.exe --overlay-ports=C:/robotology-vcpkg-binary-ports install --triplet x64-windows qt5-declarative qt5-multimedia qt5-quickcontrols2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,11 +18,10 @@ jobs:
     
     # Workaround for https://github.com/actions/virtual-environments/issues/326 until the fix is deployed
     - name: Remove
-      shell: bash 
+      shell: pwsh 
       run: |
-        rm -rf C:\Program Files (x86)\Android
-        rm -rf ${BOOST_ROOT_1_69_0}
-        rm -rf C:\Program Files\Java
+        rm -Force -Recurse -Path 'C:\Program Files (x86)\Android'
+        rm -Force -Recurse -Path 'C:\Program Files\Java'
     
     - name: Check free space 
       shell: bash 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,15 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
+    
+    - name: Check free space 
+      shell: bash 
+      run: |
+        df -h
   
     # Workaround for https://github.community/t5/GitHub-Actions/Windows-tests-worked-yesterday-broken-today/td-p/43574
-    #- name: Override bash shell PATH (windows-latest)
-    #  run: echo "::add-path::C:\Program Files\Git\bin"
+    - name: Override bash shell PATH (windows-latest)
+      run: echo "::add-path::C:\Program Files\Git\bin"
     
     - name: Download custom vcpkg and additional ports 
       shell: bash
@@ -21,13 +26,15 @@ jobs:
         mkdir C:/robotology
         git clone -b 2019.10 https://github.com/microsoft/vcpkg  C:/robotology/vcpkg
         C:/robotology/vcpkg/bootstrap-vcpkg.sh
-        sleep 1
         git clone https://github.com/robotology-dependencies/robotology-vcpkg-binary-ports C:/robotology-vcpkg-binary-ports
 
     - name: Install vcpkg ports
       shell: bash
       run: |
         # TinyXML is not installed as a workaround for https://github.com/robotology/ycm/pull/296
+        C:/robotology/vcpkg/vcpkg.exe --overlay-ports=C:/robotology-vcpkg-binary-ports install --triplet x64-windows openssl
+        # Remove temporary files https://github.com/Microsoft/vcpkg/blob/master/docs/about/faq.md#how-can-i-remove-temporary-files
+        rm -rf C:/robotology/vcpkg/buildtrees 
         C:/robotology/vcpkg/vcpkg.exe --overlay-ports=C:/robotology-vcpkg-binary-ports install --triplet x64-windows ace freeglut gsl eigen3 ode libxml2 eigen3 opencv3 matio sdl1 sdl2 qt5-base  ipopt-binary 
         # Remove temporary files https://github.com/Microsoft/vcpkg/blob/master/docs/about/faq.md#how-can-i-remove-temporary-files
         rm -rf C:/robotology/vcpkg/buildtrees 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       shell: bash
       run: |
         mkdir C:/robotology
-        git clone -b 2019.12 https://github.com/microsoft/vcpkg  C:/robotology/vcpkg
+        git clone https://github.com/microsoft/vcpkg  C:/robotology/vcpkg
         C:/robotology/vcpkg/bootstrap-vcpkg.sh
         git clone https://github.com/robotology-dependencies/robotology-vcpkg-binary-ports C:/robotology-vcpkg-binary-ports
 


### PR DESCRIPTION
With this change, the archive will be created in `C:/robotology/vcpkg` instead of `C:/vcpkg-robotology` to be compatible with a forthcoming installer that will install multiple artifacts under `C:/robotology` (the installer scripts are available in https://github.com/robotology/robotology-superbuild/pull/334). 
This change will mean that the GitHub Action code to use the archive will change from: 
~~~
    - name: Dependencies [Windows]
      if: matrix.os == 'windows-2019'
      run: |
        # To avoid spending a huge time compiling vcpkg dependencies, we download a root that comes precompiled with all the ports that we need 
        choco install -y wget unzip
        # To avoid problems with non-relocatable packages, we unzip the archive exactly in the same C:/vcpkg-robotology 
        # that has been used to create the pre-compiled archive
        cd C:/
        wget https://github.com/robotology-playground/robotology-superbuild-dependencies/releases/download/v0.0.2/vcpkg-robotology.zip
        unzip vcpkg-robotology.zip        
~~~
to 
~~~
    - name: Dependencies [Windows]
      if: matrix.os == 'windows-2019'
      run: |
        # To avoid spending a huge time compiling vcpkg dependencies, we download a root that comes precompiled with all the ports that we need 
        choco install -y wget unzip
        # To avoid problems with non-relocatable packages, we unzip the archive exactly in the same C:/vcpkg-robotology 
        # that has been used to create the pre-compiled archive
       md C:/robotology
        cd C:/robotology
        wget https://github.com/robotology-playground/robotology-superbuild-dependencies/releases/download/vx.y.z/vcpkg-robotology.zip
        unzip vcpkg-robotology.zip        
~~~